### PR TITLE
Support dark theme

### DIFF
--- a/download.html
+++ b/download.html
@@ -36,7 +36,7 @@ along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="src/css/download.css">
 </head>
 
-<body style="background: white;">
+<body>
     <header class="mdc-top-app-bar ">
         <div class="mdc-top-app-bar__row">
             <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start">

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@ along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
     <script src="src/js/viewmodel/Voice.js"></script>
 </head>
 
-<body style="background: white;" onload="main_view_init()">
+<body onload="main_view_init()">
     <div id="placeholder-app-bar"></div>
     <div id="placeholder-app-bar-menu"></div>
     <div id="placeholder-context-menu"></div>

--- a/src/css/app-bar.css
+++ b/src/css/app-bar.css
@@ -12,9 +12,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
 */
-.mdc-top-app-bar .mdc-icon-button:disabled {
-	color:#ffffff88;
-}
 #placeholder-tab-bar {
 	width: 100%;
 }

--- a/src/css/download.css
+++ b/src/css/download.css
@@ -13,9 +13,23 @@ You should have received a copy of the GNU General Public License
 along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+@media (prefers-color-scheme: light) {
+	:root {
+		--card-shadow: rgba(0, 0, 0, 0.18)
+	}
+}
+@media (prefers-color-scheme: dark) {
+	:root {
+		--card-shadow: rgba(255, 255, 255, 0.18)
+	}
+}
 #download_content {
 	text-align: center;
 }
+.mdc-card {
+	box-shadow: 0px 2px 1px -1px var(--card-shadow), 0px 1px 1px 0px var(--card-shadow), 0px 1px 3px 0px var(--card-shadow)
+}
+
 .download-card {
 	width: 400px;
 	margin: 16px auto 16px auto;
@@ -39,16 +53,16 @@ along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
 .download-card__header__text__title {
 	font-weight: bold;
 	font-size: 1.5em;
-	color: var(--mdc-theme-text-primary-on-light);
+	color: var(--mdc-theme-on-surface);
 	margin-bottom: 8px;
 }
 .download-card__header__text__subtitle {
-	color: var(--mdc-theme-text-secondary-on-light);
+	color: var(--mdc-theme-on-surface);
 }
 .download-card__badges{
 	padding-top: 16px;
 	padding-bottom: 16px;
-	background-color: white;
+	background-color: var(--mdc-theme-background);
 	text-align: center;
 }
 .download-badge {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -17,14 +17,34 @@ html {
 }
 body {
 	margin: 0px;
+	background-color: var(--mdc-theme-background);
+	color: var(--mdc-theme-text-primary-on-background);
+}
+@media (prefers-color-scheme: light) {
+	:root {
+		--mdc-theme-primary: #607D8B;
+		--mdc-theme-surface:#f6f7f9;
+		--mdc-theme-background:#fff;
+		--mdc-theme-on-primary:#fff;
+		--mdc-theme-on-surface: rgba(0, 0, 0, 0.87);
+		--mdc-theme-text-primary-on-background: rgba(0, 0, 0, 0.87);
+		--mdc-theme-text-secondary-on-background: rgba(0,0,0,0.5);
+		--mdc-theme-text-disabled-on-background: rgba(0,0,0, .38)
+	}
+}
+@media (prefers-color-scheme: dark) {
+	:root {
+		--mdc-theme-primary: #879fab;
+		--mdc-theme-surface:#181818;
+		--mdc-theme-background:#000;
+		--mdc-theme-on-primary:#fff;
+		--mdc-theme-on-surface: rgba(255, 255, 255, 0.87);
+		--mdc-theme-text-primary-on-background: rgba(255, 255, 255, 0.87);
+		--mdc-theme-text-secondary-on-background: rgba(255,255,255,0.5);
+		--mdc-theme-text-disabled-on-background: rgba(255,255,255, .38)
+	}
 }
 :root {
-	--mdc-theme-primary: #607D8B;
-	--mdc-theme-secondary: #455A64; 
-	--mdc-theme-surface:#f6f7f9;
-	--mdc-theme-text-primary-on-light: #212121;
-	--mdc-theme-text-secondary-on-light: #727272;
-	--sub-header-1: #eaeef0;
 	--app-bar-row-height: 64px;
 }
 @media (max-width: 599px) {
@@ -37,12 +57,12 @@ a:link, a.active:link,a:hover, a:visited {
 	text-decoration: none;
 	font-weight: bold;
 }
-/* https://github.com/material-components/material-components-web/issues/2718 */
-.mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
-	color: var(--mdc-theme-primary);
-}
 #content .mdc-icon-button:not(:disabled) {
 	color: var(--mdc-theme-primary);
+}
+/* https://github.com/material-components/material-components-web/issues/5699 */
+#content .mdc-icon-button:disabled {
+	color: var(--mdc-theme-text-disabled-on-background);
 }
 #content {
 	padding-top: calc(3*var(--app-bar-row-height));
@@ -60,13 +80,57 @@ a:link, a.active:link,a:hover, a:visited {
 .mdc-menu .mdc-list-item__graphic {
 	color: var(--mdc-theme-primary);
 }
+.mdc-menu .mdc-list-item {
+	color: var(--mdc-theme-text-primary-on-background);
+}
 .mdc-tab__icon img {
 	filter: grayscale(100%);
 }
+.mdc-tab .mdc-tab__icon {
+	color: var(--mdc-theme-text-secondary-on-background);
+}
+.mdc-tab .mdc-tab__text-label {
+	color: var(--mdc-theme-text-secondary-on-background);
+}
+.mdc-tab--active .mdc-tab__text-label {
+	color: var(--mdc-theme-primary);
+}
+.mdc-tab--active .mdc-tab__icon {
+	color: var(--mdc-theme-primary);
+}
 .mdc-tab--active img{
-	filter: initial;
+	filter: saturate(200%);
+
+}
+.mdc-dialog .mdc-dialog__title, .mdc-dialog .mdc-dialog__content {
+	color: var(--mdc-theme-text-primary-on-background);
+}
+/* https://github.com/material-components/material-components-web/issues/2718 */
+.mdc-text-field:not(.mdc-text-field--disabled) .mdc-floating-label {
+	color: var(--mdc-theme-text-secondary-on-background);
+}
+.mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
+	color: var(--mdc-theme-primary);
+}
+::placeholder {
+	color: var(--mdc-theme-text-secondary-on-background) !important;
+}
+.mdc-text-field--filled:not(.mdc-text-field--disabled) {
+	background-color: var(--mdc-theme-surface);
+	color: var(--mdc-theme-text-primary-on-background);
+}
+.mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__input {
+	color: var(--mdc-theme-text-primary-on-background);
 }
 
+.mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__icon--leading,
+.mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__icon--trailing
+ {
+	color: var(--mdc-theme-primary);
+}
+.mdc-text-field--focused .mdc-text-field__input {
+	background-color: var(--mdc-theme-surface);
+}
 /* Show tab icons only (no labels) on small screens */
 @media (max-width: 868px) {
 	.mdc-tab__text-label {

--- a/src/css/reader.css
+++ b/src/css/reader.css
@@ -55,7 +55,7 @@ along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
 #placeholder-reader__word-count{
 	white-space:pre;
 	font-size: 0.6em;
-	color: var(--mdc-theme-text-secondary-on-light, #727272);
+	color: var(--mdc-theme-text-secondary-on-background);
 	text-align: start;
 	margin-inline-start: 8px;
 	height: 16px;
@@ -64,7 +64,7 @@ along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
 #placeholder-reader__saved-state {
 	white-space:pre;
 	font-size: 0.6em;
-	color: var(--mdc-theme-text-secondary-on-light, #727272);
+	color: var(--mdc-theme-text-secondary-on-background);
 	text-align: end;
 	margin-inline-end: 8px;
 	height: 16px;

--- a/src/css/search-results.css
+++ b/src/css/search-results.css
@@ -70,10 +70,10 @@ along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
 }
 .list-item--sub-header-1{
 	font-weight: bold;
-	background-color: var(--sub-header-1, #dddddd);
+	background-color: var(--mdc-theme-surface);
 }
 .list-item--sub-header-2{
 	font-style: italic;
 	padding-right: 1em;
-	color: var(--mdc-theme-text-secondary-on-light, #727272);
+	color: var(--mdc-theme-text-secondary-on-background);
 }


### PR DESCRIPTION
* Use `prefers-color-theme` to specify two palette of theme colors: one for day, one for night
* Simplify color palette by replacing custom color --sub-header-1 with --mdc-theme-surface and removing unused colors
* Replace `on-light` colors with `on-background` or `on-background`
* Don't hardcode the `body` element with a white style
* Define color attributes for some widgets, whose default values only work well in a light theme:
  - text field
  - dialog
  - tabs
  - list items